### PR TITLE
Atualiza schema de ofertas e adiciona teste

### DIFF
--- a/tests/test_database_setup.py
+++ b/tests/test_database_setup.py
@@ -1,0 +1,19 @@
+import sqlite3
+import os
+import config
+import database
+
+def test_setup_database_creates_expected_columns(tmp_path):
+    db_file = tmp_path / "test.db"
+    # Usa banco temporário
+    config.DB_NAME = str(db_file)
+    assert database.setup_database() is True
+
+    conn = sqlite3.connect(str(db_file))
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(ofertas)")
+    columns = {row[1] for row in cur.fetchall()}
+    # Verifica colunas essenciais do novo esquema
+    for expected in {"asin", "url_fonte", "imagem_url"}:
+        assert expected in columns
+    conn.close()


### PR DESCRIPTION
## Summary
- adiciona colunas ausentes e índices em `setup_database`
- cria teste garantindo que o schema possua campos essenciais

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest tests/test_database_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a13c45cbd88332b212dedbf2825d3b