### PR TITLE
Add pytest unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-python@v5
-        with: 
+        with:
           python-version: "3.11"
-      
+
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest prometheus-client
-      
-      - name: Create directories
+          pip install pytest pytest-cov
+
+      - name: Run tests
         run: |
           mkdir -p reports
-          mkdir -p tests
-      
-      - name: Run scraper checks (DRY_RUN)
-        run: |
-          export DRY_RUN=1
-          python orchestrator.py --dry-run --limit 3 || true
-      
-      - name: Run orchestrator test
-        run: |
-          export DRY_RUN=1
-          python orchestrator.py --dry-run --limit 3 || true
+          pytest tests --maxfail=1 --disable-warnings \
+            --junitxml=reports/junit.xml --cov=. --cov-report=xml:reports/coverage.xml
       
       - name: Upload reports
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -79,11 +79,6 @@ debug_*.png
 cache/
 duplicate_cache.json
 
-# Test files
-teste_*.py
-test_*.py
-*_test.py
-
 # Backup files
 *.bak
 *.backup

--- a/tests/test_affiliate_links.py
+++ b/tests/test_affiliate_links.py
@@ -1,0 +1,16 @@
+import pytest
+from affiliate import AffiliateLinkConverter
+
+
+def test_detectar_loja_amazon():
+    converter = AffiliateLinkConverter()
+    loja = converter.detectar_loja("https://www.amazon.com.br/produto/dp/B0ABC123")
+    assert loja == "Amazon"
+
+
+def test_gerar_link_amazon_sync():
+    converter = AffiliateLinkConverter()
+    original = "https://www.amazon.com.br/dp/B0CHX1Q1FY"
+    affiliate = converter._gerar_link_afiliado_sync(original, "Amazon")
+    expected = f"https://www.amazon.com.br/dp/B0CHX1Q1FY?tag={converter.amazon_associate_tag}"
+    assert affiliate == expected

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,0 +1,7 @@
+from database import extrair_dominio_loja
+
+
+def test_extrair_dominio_loja():
+    url = "https://www.amazon.com.br/gp/product/B0ABC123"
+    assert extrair_dominio_loja(url) == "amazon.com.br"
+    assert extrair_dominio_loja("not a url") == ""

--- a/tests/test_promobit_scraper.py
+++ b/tests/test_promobit_scraper.py
@@ -1,0 +1,24 @@
+import pytest
+from promobit_scraper import extract_ofertas_from_html, extract_price_value
+
+
+def test_extract_ofertas_from_html_basic():
+    html = (
+        '<a href="/oferta/produto-123">'
+        '<span class="line-clamp-2">Produto 123</span>'
+        '<span class="text-primary-400">R$ 10,99</span>'
+        '<span class="font-bold text-sm">Loja X</span>'
+        '<img src="https://example.com/img.jpg" />'
+        '</a>'
+    )
+    ofertas = extract_ofertas_from_html(html)
+    assert len(ofertas) == 1
+    oferta = ofertas[0]
+    assert oferta["titulo"] == "Produto 123"
+    assert oferta["preco"] == "R$ 10,99"
+    assert oferta["url_produto"].endswith("/oferta/produto-123")
+
+
+def test_extract_price_value():
+    assert extract_price_value("R$ 1234,56") == pytest.approx(1234.56)
+    assert extract_price_value(None) is None


### PR DESCRIPTION
## Summary
- add unit tests for affiliate link conversion, Promobit scraper parsing, and database helpers
- update CI to install test deps and execute pytest with coverage reports
- stop ignoring test files in `.gitignore`

## Testing
- `python -m pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a13f16625c833291ca6f38fe7771ac