### PR TITLE
Pin additional dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,8 @@ waitress==3.0.0
 gunicorn==21.2.0
 schedule==1.2.0
 flet>=0.21.0
+webdriver-manager==4.0.2
+brotli==1.1.0
+Pillow==11.3.0
+playwright==1.54.0
+urllib3==2.5.0


### PR DESCRIPTION
## Summary
- Pin webdriver-manager, brotli, Pillow, playwright, and urllib3 in requirements.txt

## Testing
- `pip install -r requirements.txt`
- `python3 -m pytest` *(fails: ModuleNotFoundError: No module named 'promobit_scraper_new')*

------
https://chatgpt.com/codex/tasks/task_e_68a143807280833298846cb3abe60b78